### PR TITLE
Allow fetching of choice string name from choice.

### DIFF
--- a/smartchoices.py
+++ b/smartchoices.py
@@ -68,6 +68,7 @@ class ChoicesMeta(type):
 
         choices = sorted(choices, key=lambda x: x[0])
         attrs['choices'] = tuple(choices)
+        attrs['names'] = {choice[0]: choice[1] for choice in choices}
         return super(ChoicesMeta, cls).__new__(cls, name, bases, attrs)
 
 

--- a/tests.py
+++ b/tests.py
@@ -63,6 +63,15 @@ class TestChoices(unittest.TestCase):
         self.assertEqual(1000, ChoiceObj.HIGH_STARTING_CHOICE)
         self.assertEqual(1001, ChoiceObj.NEXT_CHOICE)
 
+    def test_name_from_choice(self):
+        """Choice names can be fetched by the choice."""
+
+        class ChoiceObj(smartchoices.Choices):
+            MY_CHOICE = smartchoices.Choice()
+
+        actual_name = ChoiceObj.names[ChoiceObj.MY_CHOICE]
+        self.assertEqual('MY_CHOICE', actual_name)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hey, @rockstar! We're looking for quick ways to get the string name from a choice. The current code needs to loop over the `choices` attribute to find the name. We thought it would be a nice convenience do a dict lookup like `ChoiceObj.names[ChoiceObj.MY_CHOICE]`.

Since you've got ownership of `smartchoices`, I wanted to kick a PR your way to see if it makes sense to get this feature merged and released.

Thanks!