### PR TITLE
Fix Choices.__getitem__ access for Python 3.

### DIFF
--- a/smartchoices.py
+++ b/smartchoices.py
@@ -34,13 +34,10 @@ class ChoicesMeta(type):
             JayZProblems['FOES_THAT_WANNA_MAKE_SURE_MY_CASKETS_CLOSED']
             will return 0.
         """
-        try:
-            choice_tuple_match = filter(lambda x: x[1] == key, self.choices)
-            # choice_tuple_match will be something like ((0, 'book'))
-            # and we only want the integer value in the tuple.
-            return choice_tuple_match[0][0]
-        except IndexError:
-            raise KeyError(key)
+        for value, name in self.choices:
+            if name == key:
+                return value
+        raise KeyError(key)
 
     def __new__(cls, name, bases, attrs):
         Choice.order = 0  # Reset Choice.order for every new Choices class.

--- a/tests.py
+++ b/tests.py
@@ -63,6 +63,24 @@ class TestChoices(unittest.TestCase):
         self.assertEqual(1000, ChoiceObj.HIGH_STARTING_CHOICE)
         self.assertEqual(1001, ChoiceObj.NEXT_CHOICE)
 
+    def test_get_value_by_name(self):
+        """Get the choice value from the string name."""
+
+        class ChoiceObj(smartchoices.Choices):
+            FIRST_CHOICE = smartchoices.Choice()
+            NEXT_CHOICE = smartchoices.Choice()
+
+        self.assertEqual(1, ChoiceObj['NEXT_CHOICE'])
+
+    def test_missing_name(self):
+        """An invalid key is an error."""
+
+        class ChoiceObj(smartchoices.Choices):
+            MY_CHOICE = smartchoices.Choice()
+
+        with self.assertRaises(KeyError):
+            ChoiceObj['INVALID_CHOICE']
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Howdy @rockstar. We found a case that `smartchoices` is not handling for Python 3. Details are below. It would be awesome if we could cut a release so that we don't have to keep some package patches around. You know how that goes. 😄 I hope all is well!

For Python 3, `__getitem__` fails because filter returns an iterator for
`filter` instead of a list. Because it's an iterator, accessing a
Choice class like `ChoiceObj['MY_CHOICE']` fails with:

```python
TypeError: 'filter' object is not subscriptable
```

This branch provides an alternate solution that is functionally the
same without using `filter`. Tests are included to improve coverage.